### PR TITLE
Support cross system EOL markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-conditional-loader",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "#ifdef for JavaScript",
   "main": "src/index.js",
   "directories": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-eval */
-const os = require('os')
 const { getOptions } = require('loader-utils')
 
 function getPredicate (line) {
@@ -103,7 +102,7 @@ function commentLine (line) {
 
 module.exports = function (source) {
   try {
-    const sourceByLine = source.split(os.EOL)
+    const sourceByLine = source.split(/[\r\n]+/g)
     const blocks = searchBlocks(sourceByLine)
     const truthyBlocks = getTruthyBlocks(blocks, getOptions(this))
     const transformedSource = commentCodeInsideBlocks(sourceByLine, truthyBlocks)

--- a/test/index.js
+++ b/test/index.js
@@ -1,18 +1,31 @@
 const tap = require('tap')
-const truthy = require('../build/truthy')
-const falsey = require('../build/falsey')
+const posixTruthy = require('../build/posix-truthy')
+const posixFalsey = require('../build/posix-falsey')
+const windowsTruthy = require('../build/windows-truthy')
+const windowsFalsey = require('../build/windows-falsey')
 const envVarTruthy = require('../build/env-var-truthy')
 const envVarFalsey = require('../build/env-var-falsey')
 const localVarTruthy = require('../build/local-var-truthy')
 const localVarFalsey = require('../build/local-var-falsey')
 
-tap.test('comment blocks with falsey predicate', (test) => {
-  test.equal(falsey, 1)
+
+tap.test('comment blocks with falsey predicate (POSIX EOL)', (test) => {
+  test.equal(posixFalsey, 1)
   test.end()
 })
 
-tap.test('dont comment blocks with truthy predicate', (test) => {
-  test.equal(truthy, 2)
+tap.test('dont comment blocks with truthy predicate (POSIX EOL)', (test) => {
+  test.equal(posixTruthy, 2)
+  test.end()
+})
+
+tap.test('comment blocks with falsey predicate (Windows EOL)', (test) => {
+  test.equal(windowsFalsey, 1)
+  test.end()
+})
+
+tap.test('dont comment blocks with truthy predicate (Windows EOL', (test) => {
+  test.equal(windowsTruthy, 2)
   test.end()
 })
 
@@ -35,3 +48,4 @@ tap.test('comment env var blocks with falsey predicate', (test) => {
   test.equal(localVarTruthy, true)
   test.end()
 })
+

--- a/test/test-files/posix-falsey.js
+++ b/test/test-files/posix-falsey.js
@@ -1,0 +1,7 @@
+let a = 1
+
+// #if 1 === 2
+a = 2
+// #endif
+
+module.exports = a

--- a/test/test-files/posix-truthy.js
+++ b/test/test-files/posix-truthy.js
@@ -1,0 +1,7 @@
+let a = 1
+
+// #if 1 === 1
+a = 2
+// #endif
+
+module.exports = a

--- a/test/test-files/windows-falsey.js
+++ b/test/test-files/windows-falsey.js
@@ -1,0 +1,7 @@
+let a = 1
+
+// #if 1 === 2
+a = 2
+// #endif
+
+module.exports = a

--- a/test/test-files/windows-truthy.js
+++ b/test/test-files/windows-truthy.js
@@ -1,0 +1,7 @@
+let a = 1
+
+// #if 1 === 1
+a = 2
+// #endif
+
+module.exports = a

--- a/webpack.js
+++ b/webpack.js
@@ -7,8 +7,10 @@ module.exports = {
     'env-var-falsey': './test/test-files/env-var-falsey.js',
     'local-var-truthy': './test/test-files/local-var-truthy.js',
     'local-var-falsey': './test/test-files/local-var-falsey.js',
-    'falsey': './test/test-files/falsey.js',
-    'truthy': './test/test-files/truthy.js'
+    'posix-falsey': './test/test-files/posix-falsey.js',
+    'posix-truthy': './test/test-files/posix-truthy.js',
+    'windows-falsey': './test/test-files/windows-falsey.js',
+    'windows-truthy': './test/test-files/windows-truthy.js',
   },
   output: {
     path: path.resolve(__dirname, 'build'),


### PR DESCRIPTION
**Summary:** This loader currently fails when building a package on Windows + the file's within the package have POSIX EOL markers. The root cause is that the loader splits the source file based on the [underlying OS EOL marker](https://github.com/yoannmoinet/webpack-conditional-loader/blob/master/src/index.js#L106) - the loader is unable to break up the source code into individual lines as it is splitting the source file based on the Windows EOL marker (`\r\n`) even though the file only contains POSIX EOL markers (`\n`);

To solve this problem, this pull request splits the file based on *either* POSIX *or* Windows EOL markers. 


**Testing**

1. I added test files that contain both Windows + POSIX EOL markers.  I ensured the tests failed before this change and passed with this change.
2. I tested this change on a local repo which is checked out on Windows.


---

NOTE:  This solution was originally suggested in a [previous pull request](https://github.com/caiogondim/webpack-conditional-loader/pull/6#discussion_r223614633).
